### PR TITLE
mongo example

### DIFF
--- a/maps/mongo_script.py
+++ b/maps/mongo_script.py
@@ -1,0 +1,58 @@
+import pymongo as pm
+from nomic import AtlasProject
+from sentence_transformers import SentenceTransformer
+import numpy as np
+import pandas as pd
+from pathlib import Path
+import nomic
+
+# replace with your mongodb connect string / cert
+client = pm.MongoClient('mongodb+srv://cluster0.l3jhqfs.mongodb.net/'
+                        '?authSource=%24external&authMechanism=MONGODB-X509&retryWrites=true&w=majority',
+                        tls=True,
+                        tlsCertificateKeyFile='mongocert.pem')
+
+collection = client.testdb.testcoll
+
+# Delete current content of collection
+collection.delete_many({})
+
+# Load embedding data into mongodb
+mongo_so = pd.read_parquet(Path.cwd() / 'data' / 'mongo-so.parquet')
+model = SentenceTransformer('all-MiniLM-L6-v2')
+title_embeds = model.encode(mongo_so['title'])
+mso_te = mongo_so.assign(title_embedding=list(title_embeds))
+
+data = list(r._asdict() for r in mso_te.itertuples())
+for d in data:
+    del d['Index']
+    d['title_embedding'] = d['title_embedding'].tolist()
+data[0]
+collection.insert_many(data)
+
+# Read a mongodb collection with embeddings in it and map it:
+project = AtlasProject(
+    name='MongoDB Stack Overflow Questions',
+    unique_id_field='mongo_id',
+    reset_project_if_exists=True,
+    is_public=True,
+    modality='embedding',
+)
+
+all_items = list(collection.find())
+embs = np.array([d['title_embedding'] for d in all_items])
+for d in all_items:
+    d['mongo_id'] = str(d['_id'])
+    del d['title_embedding']
+    del d['_id']
+
+project.add_embeddings(all_items, embs)
+
+project.rebuild_maps()
+project.create_index(
+    name='MongoDB Stack Overflow Questions',
+    topic_label_field='body',
+    build_topic_model=True,
+)
+
+print(project)


### PR DESCRIPTION
load embeddings into a mongodb (just as bson lists of floats on documents, which is as far as I know the expected form for the vector search product)

python maps/mongo_scripts.py from root w/ mongocert.pem in cwd:

dataset is subset of https://huggingface.co/datasets/pacovaldez/stackoverflow-questions where title `like '%mongo%'`

```
2023-06-27 16:08:42.795 | INFO     | nomic.project:__init__:1027 - Found existing project `MongoDB Stack Overflow Questions` in organization `aaron`. Clearing it of data by request.
2023-06-27 16:08:43.029 | INFO     | nomic.project:_create_project:1121 - Creating project `MongoDB Stack Overflow Questions` in organization `aaron`
6it [00:09,  1.55s/it]
2023-06-27 16:08:59.674 | INFO     | nomic.project:_add_data:1742 - Upload succeeded.
2023-06-27 16:08:59.783 | INFO     | nomic.project:rebuild_maps:1817 - Updating maps in project `MongoDB Stack Overflow Questions`
2023-06-27 16:09:00.456 | INFO     | nomic.project:create_index:1448 - Created map `MongoDB Stack Overflow Questions` in project `MongoDB Stack Overflow Questions`: https://atlas.nomic.ai/map/82091fcd-2ac6-4104-9318-b4a42c544674/11aeb2e3-cd73-44ad-b72a-897efb547b9c
MongoDB Stack Overflow Questions: https://atlas.nomic.ai/map/82091fcd-2ac6-4104-9318-b4a42c544674/11aeb2e3-cd73-44ad-b72a-897efb547b9c
```

https://atlas.nomic.ai/map/82091fcd-2ac6-4104-9318-b4a42c544674/11aeb2e3-cd73-44ad-b72a-897efb547b9c